### PR TITLE
edited condition for starting an activity to check for the badge of the activity+user's status

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -48,7 +48,6 @@ class ActivitiesController < ApplicationController
         activity.badges.each do |badge|
           if Date.today >= badge.user.classroom.date
             badge.available!
-            @activity_availability = true
           end
         end
       end

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -5,8 +5,8 @@
 <% end %>
 
 <%# Only show this link to students %>
-<%# && Only show this link if today >= show's date %>
-<% if @activity_availability %>
+<%# && Only show this link if the badge is not unavailable %>
+<% if !@activity.badges.find_by(user: current_user).unavailable?  %>
   <%= link_to "Start this activity", results_path([current_user, @activity]) unless current_user.teacher %>
 <% end %>
 


### PR DESCRIPTION
**What changed:**
- Edited condition for displaying the link to "start this activity" on the activity's show page to use the badge's status.

How to test:
- Activities where the badge's status is 'unavailable' for the user should not have the link to start displayed (on the activity's show).