### PR TITLE
homepage only shows students in the classroom

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -9,9 +9,9 @@
 
   <br>
 
-  <% @students.each do |student| %>
+  <% current_user.classroom.users.each do |user| %>
     <div>
-      <%= link_to "#{student.first_name} #{student.last_name}", profile_path(student) %>
+      <%= link_to "#{user.first_name} #{user.last_name}", profile_path(user) unless user.teacher? %>
     </div>
   <% end %>
 


### PR DESCRIPTION
**What changed:**
- When a student logs in only others in the same classroom are displayed on homepage

**How to test:**
- Log in as a student from class 1 vs class 2, should only see the corresponding students