### PR TITLE
removed d-none from a label class

### DIFF
--- a/app/assets/stylesheets/pages/_activities.scss
+++ b/app/assets/stylesheets/pages/_activities.scss
@@ -25,7 +25,3 @@
 .col-form-label {
   display: none;
 }
-
-.form-label {
-  display: none;
-}


### PR DESCRIPTION
Had d-none on the wrong class, removed it so that input labels on sign up/login pages are displayed.