### PR TITLE
Modified Classroom links and some minor component placements

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,10 +3,10 @@ class Activity < ApplicationRecord
   has_many :badges
   validates_length_of :activity_questions, maximum: :question_amount
 
-  include PgSearch::Model
-  pg_search_scope :search_by_title_and_type,
-    against: [ :title, :activity_type ],
-    using: {
-      tsearch: { prefix: true }
-    }
+  # include PgSearch::Model
+  # pg_search_scope :search_by_title_and_type,
+  #   against: [ :title, :activity_type ],
+  #   using: {
+  #     tsearch: { prefix: true }
+  #   }
 end

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -3,16 +3,16 @@
 
   <div class="blurb">
     <%= link_to "Activity Settings", settings_path(@classroom), class: "btn btn-primary" if current_user.teacher? %>
-    <p>Have a look at all the activities you can do!</p>
-    <p>Or search for an activity below:</p>
-    <%= form_with url: activities_path, method: :get, class: "d-flex w-50 my-2 mx-auto" do %>
-      <%= text_field_tag :query,
-        params[:query],
-        class: "form-control",
-        placeholder: "Find an activity"
-      %>
-      <%= submit_tag "Search", class: "btn btn-primary" %>
-    <% end %>
+    <%= "Have a look at all the activities you can do!" unless current_user.teacher? %>
+    <%# <p>Or search for an activity below:</p> %>
+    <%# <%= form_with url: activities_path, method: :get, class: "d-flex w-50 my-2 mx-auto" do %>
+      <%# <%= text_field_tag :query, %>
+        <%# params[:query], %>
+        <%# class: "form-control", %>
+        <%# placeholder: "Find an activity" %>
+      <%# %>
+      <%# <%= submit_tag "Search", class: "btn btn-primary" %>
+    <%# <% end %>
   </div>
 
   <div class="d-flex justify-content-evenly flex-wrap">

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -2,6 +2,7 @@
   <h1 class="text-center mt-3">Activities</h1>
 
   <div class="blurb">
+    <%= link_to "Activity Settings", settings_path(@classroom), class: "btn btn-primary" if current_user.teacher? %>
     <p>Have a look at all the activities you can do!</p>
     <p>Or search for an activity below:</p>
     <%= form_with url: activities_path, method: :get, class: "d-flex w-50 my-2 mx-auto" do %>
@@ -14,7 +15,7 @@
     <% end %>
   </div>
 
-  <div class="activity-grid">
+  <div class="d-flex justify-content-evenly flex-wrap">
     <% @activities.each do |activity| %>
         <% act = Activity.find_by(title: activity) %>
         <div class="activity">
@@ -42,6 +43,7 @@
     <%# end %>
 
 
-
-  <%= link_to "Back to homepage", root_path, class: "btn btn-primary" %>
+  <div class="d-flex justify-content-evenly flex-wrap">
+    <%= link_to "Back to homepage", root_path, class: "btn btn-primary" %>
+  </div>
 </div>

--- a/app/views/classrooms/settings.html.erb
+++ b/app/views/classrooms/settings.html.erb
@@ -19,7 +19,7 @@
 
     <div class="d-flex justify-content-evenly flex-wrap">
       <%= link_to "Back to Classroom", classroom_path(current_user.classroom), class: "btn btn-primary" %>
-      <%= link_to "Back to Activities", activities_path, class: "btn btn-primary" %>
+      <%= link_to "Back to Activities", activities_path, class: "btn btn-primary", target: :_blank %>
     </div>
 
 </div>

--- a/app/views/classrooms/settings.html.erb
+++ b/app/views/classrooms/settings.html.erb
@@ -17,8 +17,9 @@
       </div>
     <% end %>
 
-    <div class="d-flex justify-content-center">
+    <div class="d-flex justify-content-evenly flex-wrap">
       <%= link_to "Back to Classroom", classroom_path(current_user.classroom), class: "btn btn-primary" %>
+      <%= link_to "Back to Activities", activities_path, class: "btn btn-primary" %>
     </div>
 
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -34,16 +34,15 @@
     </ul>
   </div>
 
-  <% if current_user %>
-    <div class="d-flex justify-content-evenly flex-wrap">
-      <%= link_to "Enter The Classroom", classroom_path(current_user.classroom), class: "btn btn-primary mb-1", style: "min-width: 200px;" %>
+  <div class="d-flex justify-content-evenly flex-wrap">
+    <% if current_user %>
+      <%= link_to "Enter The Classroom", classroom_path(current_user.classroom), class: "btn btn-primary mb-1", style: "min-width: 200px;" if current_user.teacher? %>
       <%= link_to "Show Information", play_path, class: "btn btn-primary mb-1", style: "min-width: 200px;"  %>
-      <%= link_to "Your Activities", activities_path, class: "btn btn-primary mb-1", style: "min-width: 200px;"  if current_user.teacher == false  %>
-    </div>
-  <% else %>
-    <div class="d-flex justify-content-center">
-      <%= link_to "Sign up", new_registration_path(:user), class: "btn btn-primary" %>
-    </div>
-  <% end %>
+      <%= link_to "Your Activities", activities_path, class: "btn btn-primary mb-1", style: "min-width: 200px;" unless current_user.teacher?  %>
+    <% else %>
+      <%= link_to "Login", new_user_session_path, class: "btn btn-primary" %>
+      <%= link_to "Sign up", new_user_registration_path, class: "btn btn-primary" %>
+    <% end %>
+  </div>
 
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,7 +10,7 @@
       <ul class="navbar-nav me-auto">
         <% if user_signed_in? %>
           <li class="nav-item active">
-            <%= link_to "Classroom", classroom_path(current_user.classroom), class: "nav-link" %>
+            <%= link_to "Classroom", classroom_path(current_user.classroom), class: "nav-link" if current_user.teacher? %>
           </li>
           <li class="nav-item">
             <%= link_to "Show Info", play_path, class: "nav-link" %>
@@ -22,6 +22,7 @@
             <%= image_tag "user.png", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
             <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
               <%= link_to "Admin", dashboard_path, class: "dropdown-item" if current_user.admin? %>
+              <%= link_to "Settings", settings_path(current_user.classroom), class: "dropdown-item" if current_user.teacher? %>
               <%= link_to "My Profile", profile_path(current_user), class: "dropdown-item" %>
               <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
             </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,7 +13,7 @@
             <%= link_to "Classroom", classroom_path(current_user.classroom), class: "nav-link" if current_user.teacher? %>
           </li>
           <li class="nav-item">
-            <%= link_to "Show Info", play_path, class: "nav-link" %>
+            <%= link_to "Performance", play_path, class: "nav-link" %>
           </li>
           <li>
             <%= link_to "Activities", activities_path, class: "nav-link" %>


### PR DESCRIPTION
Lots of little fixes, I may have forgotten some but I'll try to list them here:
- Classroom links only appear for teachers
- Settings page link in the activities index page for teachers
- Activities index page opens new tab from link in settings page
- Search bar is removed, but only commented out for now
- Lots of little style fixes, minor component adjustments
  - Presentation instead of Show or Play
  - Other small Nav bar fixes, as requested