### PR TITLE
Bug style fixes

### DIFF
--- a/app/policies/classroom_policy.rb
+++ b/app/policies/classroom_policy.rb
@@ -7,7 +7,7 @@ class ClassroomPolicy < ApplicationPolicy
   end
 
   def show?
-    true
+    true if @user.teacher
   end
 
   def settings?

--- a/app/views/classrooms/show.html.erb
+++ b/app/views/classrooms/show.html.erb
@@ -11,7 +11,7 @@
       <p>The showing is on <%= @classroom.date.strftime("%A, %B %d %Y at %H%M %Z") %></p>
       <p>This classroom's access code is: <strong><%= @classroom.access_code %></strong> - Share it with your students!</p>
       <p><%= link_to "Your classroom settings", settings_path(@classroom), class: "btn btn-primary" %></p>
-      <p>Have a look at your students' progress:</p>
+      <p> <%= "Have a look at your students progress:" unless @students.empty? %> </p>
     </div>
     <% @students.each do |student| %>
       <div class="student-row">


### PR DESCRIPTION
**What changed:**
- Modified "show" action in ClassroomPolicy to only authorize teachers to see the classroom page
- The "Have a look at your students' progress" text in the classroom page doesn't appear if there are no students yet