### PR TITLE
Sign up path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "sassc-rails"
 
 gem "devise"
 gem "autoprefixer-rails"
-gem "font-awesome-sass", "~> 6.1"
+gem "font-awesome-sass", "~> 6.2"
 gem "simple_form", github: "heartcombo/simple_form"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,7 @@ DEPENDENCIES
   debug
   devise
   dotenv-rails
-  font-awesome-sass (~> 6.1)
+  font-awesome-sass (~> 6.2)
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/assets/stylesheets/components/_frame.scss
+++ b/app/assets/stylesheets/components/_frame.scss
@@ -4,4 +4,14 @@
   flex-direction: column;
   align-items: start;
   justify-content: center;
+
+  input {
+    border: none;
+    box-shadow: rgba(31, 127, 255, 0.3) 0px 1px;
+    border-radius: 0;
+
+    &:focus {
+      box-shadow: $blue 0px 1px;
+    }
+  }
 }

--- a/app/assets/stylesheets/components/_frame.scss
+++ b/app/assets/stylesheets/components/_frame.scss
@@ -1,0 +1,7 @@
+.frame {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  justify-content: center;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -14,6 +14,7 @@
 @import "banner";
 @import "tooltip";
 @import "input";
+@import "frame";
 
 
 .content-wrap {

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -13,6 +13,8 @@
 @import "home";
 @import "banner";
 @import "tooltip";
+@import "input";
+
 
 .content-wrap {
   padding-bottom: 4px;

--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -30,4 +30,5 @@
 .category-selector:checked + label {
   color: white !important;
   background-color: rgba(55, 130, 241, 0.7);
+  border: 2px solid $blue;
 }

--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -1,11 +1,12 @@
 .category-wrapper {
   display: flex;
-  justify-content: space-between;
+  justify-content: space-evenly;
   flex-wrap: wrap;
 }
 
 .category-item {
   flex: 0 0 30%;
+  margin-right: 10px;
 }
 
 .category-selector {
@@ -28,5 +29,5 @@
 
 .category-selector:checked + label {
   color: white !important;
-  background-color: $primary;
+  background-color: rgba(55, 130, 241, 0.7);
 }

--- a/app/assets/stylesheets/components/_input.scss
+++ b/app/assets/stylesheets/components/_input.scss
@@ -1,0 +1,32 @@
+.category-wrapper {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.category-item {
+  flex: 0 0 30%;
+}
+
+.category-selector {
+  position: absolute;
+  transform: scale(0);
+}
+
+.category-selector + label {
+  display: block;
+  cursor: pointer;
+  box-sizing: border-box;
+  width: 100%;
+  text-align: center;
+  font-size: 24px;
+  padding: 20px;
+  border: 1px solid #ced4da;
+  border-radius: 5px;
+  background-color: white;
+}
+
+.category-selector:checked + label {
+  color: white !important;
+  background-color: $primary;
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "bootstrap"
+import "@hotwired/stimulus"

--- a/app/javascript/controllers/edit_ajax_controller.js
+++ b/app/javascript/controllers/edit_ajax_controller.js
@@ -44,6 +44,5 @@ export default class extends Controller {
     event.preventDefault();
     this.commentInfoTarget.classList.add("d-none");
     this.commentEditTarget.classList.remove("d-none");
-
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -15,3 +15,9 @@ application.register("hello", HelloController)
 
 import MapController from "./map_controller"
 application.register("map", MapController)
+
+import { Application } from '@hotwired/stimulus'
+import ScrollReveal from 'stimulus-scroll-reveal'
+
+const application = Application.start()
+application.register('scroll-reveal', ScrollReveal)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,11 +4,11 @@
 
 import { application } from "./application"
 
-import EditAjaxController from "./edit_ajax_controller"
-application.register("edit-ajax", EditAjaxController)
-
 import ClassroomActivityController from "./classroom_activity_controller"
 application.register("classroom-activity", ClassroomActivityController)
+
+import EditAjaxController from "./edit_ajax_controller"
+application.register("edit-ajax", EditAjaxController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
@@ -16,5 +16,5 @@ application.register("hello", HelloController)
 import MapController from "./map_controller"
 application.register("map", MapController)
 
-import ScrollTo from 'stimulus-scroll-to'
-application.register("scroll-to", ScrollTo)
+import SignupController from "./signup_controller"
+application.register("signup", SignupController)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,8 +16,5 @@ application.register("hello", HelloController)
 import MapController from "./map_controller"
 application.register("map", MapController)
 
-import { Application } from '@hotwired/stimulus'
-import ScrollReveal from 'stimulus-scroll-reveal'
-
-const application = Application.start()
-application.register('scroll-reveal', ScrollReveal)
+import ScrollTo from 'stimulus-scroll-to'
+application.register("scroll-to", ScrollTo)

--- a/app/javascript/controllers/signup_controller.js
+++ b/app/javascript/controllers/signup_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="signup"
+export default class extends Controller {
+  static targets = ["codeText"]
+
+  connect() {
+  }
+
+  displayText(event) {
+    // console.log(event.target.value);
+    if (event.target.value == 'false') {
+      this.codeTextTarget.innerHTML = "This is the code given to you by your teacher. <br> With this code, you will be added to your virtual classroom with your teacher and your peers."
+    } else if (event.target.value == 'true') {
+      this.codeTextTarget.innerHTML = "This was the code given to you by Tableau D'Hote. <br> With this code, a classroom will be created for your students where you will be assigned as their teacher."
+    }
+  }
+}

--- a/app/javascript/controllers/signup_controller.js
+++ b/app/javascript/controllers/signup_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
     if (event.target.value == 'false') {
       this.codeTextTarget.innerHTML = "This is the code given to you by your teacher. <br> With this code, you will be added to your virtual classroom with your teacher and your peers."
     } else if (event.target.value == 'true') {
-      this.codeTextTarget.innerHTML = "This was the code given to you by Tableau D'Hote. <br> With this code, a classroom will be created for your students where you will be assigned as their teacher."
+      this.codeTextTarget.innerHTML = "This is the code given to you by Tableau D'Hote. <br> With this code, a classroom will be created for your students where you will be assigned as their teacher."
     }
   }
 }

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -14,7 +14,6 @@
     <% else %>
       <h3>You can't complete this activity yet!</h3>
     <% end %>
-
   </div>
   <div class="d-flex justify-content-evenly flex-wrap">
     <p class="text-center"><%= link_to "Back to activities", activities_path, class: "btn btn-primary mb-1", style: "min-width: 200px;" %></p>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,19 +9,19 @@
   <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }) do |f| %>
     <%= f.error_notification %>
 
-    <div class="form-inputs">
+    <div class="form-inputs" data-controller="signup">
       <div id="frame1" class="frame">
         <h3 class="my-5">Let's start with your name.</h3>
         <div class="d-flex" style="width: 100%">
           <div class="flex-fill me-2">
             <%= f.input :first_name,
-                          required: true,
-                          input_html: { autocomplete: "First Name"} %>
+                        required: true,
+                        input_html: { autocomplete: "First Name"} %>
           </div>
           <div class="flex-fill">
             <%= f.input :last_name,
-                          required: true,
-                          input_html: { autocomplete: "Last Name" } %>
+                        required: true,
+                        input_html: { autocomplete: "Last Name" } %>
           </div>
         </div>
         <%= link_to "#frame2", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
@@ -38,7 +38,7 @@
                     collection_wrapper_tag: 'div',
                     collection_wrapper_class: 'category-wrapper',
                     item_wrapper_class: 'category-item',
-                    input_html: { class: 'category-selector' } %>
+                    input_html: { class: 'category-selector', data: { action: "change->signup#displayText" }} %>
         <%= link_to "#frame3", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
           OK <i class="fa-solid fa-check"></i>
         <% end %>
@@ -46,11 +46,12 @@
 
       <div id="frame3" class="frame">
         <h3 class="my-3">What is your access code?</h3>
-        <p>This was the code given to you by Tableau D'Hote.</p>
-        <p class="mb-4">With this code, a classroom will be created for your students where you will be assigned as their teacher.</p>
+        <p class="code-text mb-4" data-signup-target="codeText">This is the code given to you by your teacher. <br> With this code, you will be added to your virtual classroom with your teacher and your peers.</p>
 
         <%= f.input :access_code,
                     required: true,
+                    label: false,
+                    placeholder: "Enter your code...",
                     input_html: { autocomplete: "access_code" }%>
         <%= link_to "#frame4", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
           OK <i class="fa-solid fa-check"></i>
@@ -61,6 +62,8 @@
         <h3 class="my-5">What is your email address?</h3>
         <%= f.input :email,
                     required: true,
+                    label: false,
+                    placeholder: "Enter your email...",
                     input_html: { autocomplete: "email" } %>
         <%= link_to "#frame5", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
           OK <i class="fa-solid fa-check"></i>
@@ -77,7 +80,7 @@
                     required: true,
                     input_html: { autocomplete: "new-password" } %>
         <div class="form-actions">
-          <%= f.button :submit, "Sign up", class: "btn btn-primary mb-2" %>
+          <%= f.button :submit, "Sign up", class: "btn btn-primary mb-2 rounded-2" %>
         </div>
       </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,7 +6,7 @@
     <p class="my-3">Already have an account? <%= render "devise/shared/links" %></p>
   </div>
 
-  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }) do |f| %>
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }, html: { onkeydown: "return event.key != 'Enter';"} ) do |f| %>
     <%= f.error_notification %>
 
     <div class="form-inputs" data-controller="signup">
@@ -52,7 +52,7 @@
                     required: true,
                     label: false,
                     placeholder: "Enter your code...",
-                    input_html: { autocomplete: "access_code" }%>
+                    input_html: { autocomplete: "access_code" } %>
         <%= link_to "#frame4", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
           OK <i class="fa-solid fa-check"></i>
         <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,10 +7,12 @@
     <div class="form-inputs">
       <div>
         <h3>Are you a teacher or student?</h3>
-        <%= f.collection_radio_buttons :teacher, [[true, 'Teacher'], [false, 'Student']], :first, :last,
+        <%= f.input :teacher, as: :radio_buttons, collection: [[true, 'Teacher'], [false, 'Student']], label_method: :second, value_method: :first,
                   required: true,
-                  autofocus: true,
-                  input_html: { autocomplete: "teacher" } %>
+                  collection_wrapper_tag: 'div',
+                  collection_wrapper_class: 'category-wrapper',
+                  item_wrapper_class: 'category-item',
+                  input_html: {class: 'category-selector'} %>
       </div>
       <%= f.input :email,
                   required: true,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,18 +1,17 @@
 <div class="container" style="width: 60%">
-  <div class="frame">
-    <h1 class="my-3">Welcome to the <span class="text-primary">Interactive Theater Companion</span>! </h1>
+  <div id="frame0" class="frame">
+    <h1 class="my-3">Welcome to the <span class="text-primary">Interactive Theater Companion</span> </h1>
     <h3 class="my-3">We're thrilled to have you here. Create your account to begin your experience.</h3>
     <%= link_to "Get started", "#frame1", class: "btn btn-primary my-3", data: { controller: "scroll-to" } %>
     <p class="my-3">Already have an account? <%= render "devise/shared/links" %></p>
   </div>
-
 
   <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }) do |f| %>
     <%= f.error_notification %>
 
     <div class="form-inputs">
       <div id="frame1" class="frame">
-        <h3>Let's start with your name.</h3>
+        <h3 class="my-5">Let's start with your name.</h3>
         <div class="d-flex" style="width: 100%">
           <div class="flex-fill me-2">
             <%= f.input :first_name,
@@ -25,11 +24,13 @@
                           input_html: { autocomplete: "Last Name" } %>
           </div>
         </div>
-        <%= link_to "Enter", "#frame2", class: "btn btn-primary", data: { controller: "scroll-to" } %>
+        <%= link_to "#frame2", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
+          OK <i class="fa-solid fa-check"></i>
+        <% end %>
       </div>
 
       <div id="frame2" class="frame">
-        <h3>Are you a teacher or student?</h3>
+        <h3 class="my-5">Are you a teacher or student?</h3>
         <%= f.input :teacher, as: :radio_buttons,
                     collection: [[true, 'Teacher'], [false, 'Student']],
                     label_method: :second, value_method: :first,
@@ -38,33 +39,50 @@
                     collection_wrapper_class: 'category-wrapper',
                     item_wrapper_class: 'category-item',
                     input_html: { class: 'category-selector' } %>
+        <%= link_to "#frame3", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
+          OK <i class="fa-solid fa-check"></i>
+        <% end %>
       </div>
 
-      <div id="frame-3" class="frame">
+      <div id="frame3" class="frame">
+        <h3 class="my-3">What is your access code?</h3>
+        <p>This was the code given to you by Tableau D'Hote.</p>
+        <p class="mb-4">With this code, a classroom will be created for your students where you will be assigned as their teacher.</p>
+
+        <%= f.input :access_code,
+                    required: true,
+                    input_html: { autocomplete: "access_code" }%>
+        <%= link_to "#frame4", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
+          OK <i class="fa-solid fa-check"></i>
+        <% end %>
+      </div>
+
+      <div id="frame4" class="frame">
+        <h3 class="my-5">What is your email address?</h3>
         <%= f.input :email,
                     required: true,
                     input_html: { autocomplete: "email" } %>
+        <%= link_to "#frame5", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
+          OK <i class="fa-solid fa-check"></i>
+        <% end %>
       </div>
 
-      <%= f.input :password,
-                  required: true,
-                  hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                  input_html: { autocomplete: "new-password" } %>
-      <%= f.input :password_confirmation,
-                  required: true,
-                  input_html: { autocomplete: "new-password" } %>
-      <%= f.input :access_code,
-                  required: true,
-                  input_html: { autocomplete: "access_code" }%>
-      <%#= f.select :classroom_id,
-                  options_from_collection_for_select(Classroom.all, "id", "name"),
-                  required: true,
-                  input_html: { autocomplete: "classroom" }%>
+      <div id="frame5" class="frame">
+        <h3 class="my-5">Lastly, please create a password for your account.</h3>
+        <%= f.input :password,
+                    required: true,
+                    hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+                    input_html: { autocomplete: "new-password" } %>
+        <%= f.input :password_confirmation,
+                    required: true,
+                    input_html: { autocomplete: "new-password" } %>
+        <div class="form-actions">
+          <%= f.button :submit, "Sign up", class: "btn btn-primary mb-2" %>
+        </div>
+      </div>
+
     </div>
 
-    <div class="form-actions">
-      <%= f.button :submit, "Sign up", class: "btn btn-primary mb-2" %>
-    </div>
   <% end %>
 
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,6 +5,13 @@
     <%= f.error_notification %>
 
     <div class="form-inputs">
+      <div>
+        <h3>Are you a teacher or student?</h3>
+        <%= f.collection_radio_buttons :teacher, [[true, 'Teacher'], [false, 'Student']], :first, :last,
+                  required: true,
+                  autofocus: true,
+                  input_html: { autocomplete: "teacher" } %>
+      </div>
       <%= f.input :email,
                   required: true,
                   autofocus: true,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,37 +1,51 @@
 <div class="container" style="width: 60%">
-  <h2 class="text-center mt-3">Create an account</h2>
+  <div class="frame">
+    <h1 class="my-3">Welcome to the <span class="text-primary">Interactive Theater Companion</span>! </h1>
+    <h3 class="my-3">We're thrilled to have you here. Create your account to begin your experience.</h3>
+    <%= link_to "Get started", "#frame1", class: "btn btn-primary my-3", data: { controller: "scroll-to" } %>
+    <p class="my-3">Already have an account? <%= render "devise/shared/links" %></p>
+  </div>
+
 
   <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }) do |f| %>
     <%= f.error_notification %>
 
     <div class="form-inputs">
-      <div>
+      <div id="frame1" class="frame">
+        <h3>Let's start with your name.</h3>
+        <div class="d-flex" style="width: 100%">
+          <div class="flex-fill me-2">
+            <%= f.input :first_name,
+                          required: true,
+                          input_html: { autocomplete: "First Name"} %>
+          </div>
+          <div class="flex-fill">
+            <%= f.input :last_name,
+                          required: true,
+                          input_html: { autocomplete: "Last Name" } %>
+          </div>
+        </div>
+        <%= link_to "Enter", "#frame2", class: "btn btn-primary", data: { controller: "scroll-to" } %>
+      </div>
+
+      <div id="frame2" class="frame">
         <h3>Are you a teacher or student?</h3>
-        <%= f.input :teacher, as: :radio_buttons, collection: [[true, 'Teacher'], [false, 'Student']], label_method: :second, value_method: :first,
-                  required: true,
-                  collection_wrapper_tag: 'div',
-                  collection_wrapper_class: 'category-wrapper',
-                  item_wrapper_class: 'category-item',
-                  input_html: {class: 'category-selector'} %>
+        <%= f.input :teacher, as: :radio_buttons,
+                    collection: [[true, 'Teacher'], [false, 'Student']],
+                    label_method: :second, value_method: :first,
+                    required: true,
+                    collection_wrapper_tag: 'div',
+                    collection_wrapper_class: 'category-wrapper',
+                    item_wrapper_class: 'category-item',
+                    input_html: { class: 'category-selector' } %>
       </div>
-      <%= f.input :email,
-                  required: true,
-                  autofocus: true,
-                  input_html: { autocomplete: "email" }%>
-      <div class="d-flex" style="width: 100%">
-        <div class="flex-fill me-2">
-          <%= f.input :first_name,
-                        required: true,
-                        autofocus: true,
-                        input_html: { autocomplete: "First Name"} %>
-        </div>
-        <div class="flex-fill">
-          <%= f.input :last_name,
-                        required: true,
-                        autofocus: true,
-                        input_html: { autocomplete: "Last Name" } %>
-        </div>
+
+      <div id="frame-3" class="frame">
+        <%= f.input :email,
+                    required: true,
+                    input_html: { autocomplete: "email" } %>
       </div>
+
       <%= f.input :password,
                   required: true,
                   hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
@@ -41,7 +55,6 @@
                   input_html: { autocomplete: "new-password" } %>
       <%= f.input :access_code,
                   required: true,
-                  autofocus: true,
                   input_html: { autocomplete: "access_code" }%>
       <%#= f.select :classroom_id,
                   options_from_collection_for_select(Classroom.all, "id", "name"),
@@ -54,5 +67,4 @@
     </div>
   <% end %>
 
-  <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Already have an account? Log in here.", new_session_path(resource_name), class: "text-decoration-none" %><br />
+  <%= link_to "Log in here.", new_session_path(resource_name), class: "text-decoration-none" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@hotwired/turbo-rails": "^7.2.4",
     "@popperjs/core": "^2.11.6",
     "bootstrap": "^5.2.3",
+    "stimulus-scroll-reveal": "^3.1.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@popperjs/core": "^2.11.6",
     "bootstrap": "^5.2.3",
     "stimulus-scroll-reveal": "^3.1.0",
+    "stimulus-scroll-to": "^4.1.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,6 +702,11 @@ stimulus-scroll-reveal@^3.1.0:
   resolved "https://registry.yarnpkg.com/stimulus-scroll-reveal/-/stimulus-scroll-reveal-3.1.0.tgz#ffb087f802d8f8d23cb174ecf5f869e98172888b"
   integrity sha512-3xfiNgwgAM70F6Phy14CCVto3O2gIXiOd4arvqHD+sPv5EdRJ1rav+So2T+IZz89IT3AagF3I7ZY7DgeHm/iNg==
 
+stimulus-scroll-to@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-scroll-to/-/stimulus-scroll-to-4.1.0.tgz#22b24d768d673f029ab0f68100556e113075fa95"
+  integrity sha512-bKltfECyU8y/ck8yXy77hlK/vv85igW7LPtZpgkUBFuAGz+Ou7EnMPpKrSJiYoK+TXS2COFilb/PGND/xISxJA==
+
 supports-color@^8.0.0:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,6 +697,11 @@ source-map@^0.6.0:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+stimulus-scroll-reveal@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-scroll-reveal/-/stimulus-scroll-reveal-3.1.0.tgz#ffb087f802d8f8d23cb174ecf5f869e98172888b"
+  integrity sha512-3xfiNgwgAM70F6Phy14CCVto3O2gIXiOd4arvqHD+sPv5EdRJ1rav+So2T+IZz89IT3AagF3I7ZY7DgeHm/iNg==
+
 supports-color@^8.0.0:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"


### PR DESCRIPTION
**What changed:**
- Split signup page into different sections 
- Added styling / JS to handle scroll + text change for the Access Code section

**How to test:**
- Sign up and go through the flow. Access Code section text should change depending if you clicked "Student" or "Teacher
- Click sign up and check that you signed up properly

**Left to do:** 
- If an input is empty, clicking "OK" should not move you forward & display an error message instead
- Adjust scroll behaviour so transition is smoother between sections