### PR TITLE
Show activities to teachers

### DIFF
--- a/app/views/activities/_multiple_pop_up.html.erb
+++ b/app/views/activities/_multiple_pop_up.html.erb
@@ -6,27 +6,27 @@
   <div class="text-center">
     <%= cl_image_tag activity.photos.first.key, usemap: "#map", class: "rounded-2" %>
     <map name="map">
-        <area id="star1" shape="rect" coords="146,390,288,533" href="" alt="star1" data-bs-toggle="modal" data-bs-target="#modal1">
-        <area id="star2" shape="rect" coords="526,90,646,198" href="https://setapp.com/how-to/paint-for-mac" alt="star2" data-bs-toggle="modal" data-bs-target="#modal2">
-        <area id="star3" shape="rect" coords="973,246,1097,352" href="https://setapp.com/how-to/paint-for-mac" alt="star3" data-bs-toggle="modal" data-bs-target="#modal3">
-        <% activity.activity_questions.each_with_index do |question, i| %>
-          <div class="modal fade" id="modal<%= i + 1 %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <h5 class="modal-title" id="exampleModalLabel">Monument National</h5>
-                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                  <p><%= question.question_text %></p>
-                </div>
-                <div class="modal-footer">
-                  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                </div>
+      <area id="star1" shape="rect" coords="146,390,288,533" href="" alt="star1" data-bs-toggle="modal" data-bs-target="#modal1">
+      <area id="star2" shape="rect" coords="526,90,646,198" href="https://setapp.com/how-to/paint-for-mac" alt="star2" data-bs-toggle="modal" data-bs-target="#modal2">
+      <area id="star3" shape="rect" coords="973,246,1097,352" href="https://setapp.com/how-to/paint-for-mac" alt="star3" data-bs-toggle="modal" data-bs-target="#modal3">
+      <% activity.activity_questions.each_with_index do |question, i| %>
+        <div class="modal fade" id="modal<%= i + 1 %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="exampleModalLabel">Monument National</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+              </div>
+              <div class="modal-body">
+                <p><%= question.question_text %></p>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
               </div>
             </div>
           </div>
-        <% end %>
+        </div>
+      <% end %>
     </map>
 
   <% if current_user == @profile && @badge.status != "completed" %>

--- a/app/views/activities/_review_activity.html.erb
+++ b/app/views/activities/_review_activity.html.erb
@@ -24,14 +24,6 @@
 
         <% question.user_responses.where(user: profile).each do |response| %>
           <%= render 'activities/user_responses_info', question: question, response: response %>
-          <% if @badge.status == "marked" || @badge.status == "completed" %>
-            <% if response.text == question.response_text %>
-              <p class="my-2">Correction: <span class="text-success">Correct Answer</span></p>
-            <% else %>
-              <p class="my-2">Correction: <span class="text-danger">Wrong Answer</span></p>
-              <p><%= "The correct answer is: #{question.response_text}" unless current_user.teacher %>  </p>
-            <% end %>
-          <% end %>
 
           <% if current_user.teacher? && response.teacher_comments.empty? %>
             <%= simple_form_for([response, teacher_comment]) do |f| %>

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -7,16 +7,23 @@
       <%= render 'activities/teacher/video_quiz', activity: @activity %>
     <% when "Essay" %>
     <% when "Review" %>
+    <% when "Video Essay" %>
     <% when "Match" %>
       <%= render 'activities/teacher/video_quiz', activity: @activity %>
     <% when "Art" %>
       <%= render 'activities/teacher/video_quiz', activity: @activity %>
     <% when "Crossword" %>
-      <%= render 'activities/teacher/crossword', activity: @activity, activity_questions: @activity_questions, profile: @profile, user_response: @user_response, teacher_comment: @teacher_comment %>
+      <%= render 'activities/teacher/crossword', activity: @activity %>
+    <% when "Audio Pop-up" %>
+      <%= render 'activities/teacher/audio', activity: @activity %>
     <% when "Photo Popup" %>
       <%= render 'activities/teacher/photo_popup', activity: @activity %>
     <% when "Video Quiz" %>
       <%= render 'activities/teacher/video_quiz', activity: @activity %>
+    <% when "Icon" %>
+      <%= render 'activities/teacher/icon', activity: @activity %>
+    <% when "Multiple" %>
+      <%= render 'activities/teacher/multiple', activity: @activity %>
     <% else %>
       <%= render 'activities/activity_error', activity: @activity %>
     <% end %>

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -1,21 +1,30 @@
 <div class="container">
   <h1 class="text-center mt-3"><%= @activity.title %></h1>
   <h4 class="question"><%= @activity.description %></h4>
-  <div class="d-flex flex-column align-items-center">
-    <% if @activity.activity_type.name == "Photo Popup" %>
-      <div>
-        <% @activity.activity_questions.each do |aq| %>
-          <% aq.photos.each do |photo| %>
-            <%= cl_image_tag photo.key, height: 500, width: 400, crop: :fill, class: "rounded-2 m-3", style: "box-shadow: 0 5px 9px rgba(0,0,0,0.2);" %>
-          <% end %>
-        <% end %>
-      </div>
+  <% if current_user.teacher? %>
+    <% case @activity.activity_type.name %>
+    <% when "Quiz" %>
+      <%= render 'activities/teacher/video_quiz', activity: @activity %>
+    <% when "Essay" %>
+    <% when "Review" %>
+    <% when "Match" %>
+      <%= render 'activities/teacher/video_quiz', activity: @activity %>
+    <% when "Art" %>
+      <%= render 'activities/teacher/video_quiz', activity: @activity %>
+    <% when "Crossword" %>
+      <%= render 'activities/teacher/crossword', activity: @activity, activity_questions: @activity_questions, profile: @profile, user_response: @user_response, teacher_comment: @teacher_comment %>
+    <% when "Photo Popup" %>
+      <%= render 'activities/teacher/photo_popup', activity: @activity %>
+    <% when "Video Quiz" %>
+      <%= render 'activities/teacher/video_quiz', activity: @activity %>
+    <% else %>
+      <%= render 'activities/activity_error', activity: @activity %>
     <% end %>
-  </div>
+  <% end %>
 
-  <%# Only show this link to students %>
-  <%# && Only show this link if the badge is not unavailable %>
   <div class="d-flex justify-content-evenly">
+    <%# Only show this link to students %>
+    <%# && Only show this link if the badge is not unavailable %>
     <% if current_user.teacher? || @activity.badges.find_by(user: current_user).active?  %>
       <p class="text-center"><%= link_to "Start this activity", results_path([current_user, @activity]), class: "btn btn-primary mb-1", style: "min-width: 200px;" unless current_user.teacher %></p>
     <% else %>

--- a/app/views/activities/teacher/_audio.html.erb
+++ b/app/views/activities/teacher/_audio.html.erb
@@ -1,0 +1,4 @@
+<div class="image-audio text-center d-flex flex-column justify-content-center align-items-center">
+  <%= cl_image_tag @activity.activity_questions.first.photos.first.key, height: 485, width: 400, crop: :fill, class: "rounded-3 mb-1" %>
+  <%= audio_tag("Julie Tamiko Manning interview.m4a", controls: true) %>
+</div>

--- a/app/views/activities/teacher/_crossword.html.erb
+++ b/app/views/activities/teacher/_crossword.html.erb
@@ -1,0 +1,28 @@
+  <div class="d-flex">
+    <div id="puzzle_container">
+      <table id="puzzle">
+      </table>
+    </div>
+
+    <div class="m-2">
+      <h5><strong>Horizontal</strong></h5>
+      <p>3. a person who learns another's role in order to be able to act as a replacement at short notice - <span style="color:green">Understudy</span> </p>
+      <p>4. the eyes, ears and hands of the stage manager in the back-stage area (abbreviated) -  <span style="color:green">ASM</span></p>
+      <p>6. also known as the dramatist who is a person who writes plays - <span style="color:green">Playwright</span></p>
+      <p>7. a person whose profession is acting on the stage - <span style="color:green">Actor</span></p>
+      <p>8. a person who oversees all aspects of mounting a theatre production - <span style="color:green">Producer</span></p>
+
+      <h5><strong>Vertical</strong></h5>
+      <p>1. provide practical and organizational support to the director, actors, designers, stage crew and technicians throughout the production - <span style="color:green">Stage Manager</span></p>
+      <p>2. expert who supervises the activities of all technical departments and oversees the use and maintenance of theater equipment (abbreviated) - <span style="color:green">TD</span></p>
+      <p>5. oversees and orchestrates the mounting of a theatre production - <span style="color:green">Director</span></p>
+    </div>
+  </div>
+
+  <div id="buttons_container">
+    <button id="clear_all" class="btn btn-primary">Clear All</button>
+    <button id="check" class="btn btn-primary">Check</button>
+    <button id="solve" class="btn btn-primary">Solve</button>
+    <button id="clue" class="btn btn-primary">Clue</button>
+  </div>
+<%= javascript_include_tag 'crossword' %>

--- a/app/views/activities/teacher/_icon.html.erb
+++ b/app/views/activities/teacher/_icon.html.erb
@@ -1,0 +1,26 @@
+<div>
+  <p class="text-center">Scroll over the Kanji to see their meaning. Click on the Kanji to hear them pronounced.</p>
+  <div class="character-icons">
+    <% icons = [] %>
+    <% @activity.activity_questions.each do |e| %>
+      <% icons << e.question_text %>
+    <% end %>
+    <h1 class="text-center mt-4" ><%= icons.join %></h1>
+    <%= audio_tag("#{icons.join} audio.m4a", id:"icon-audio") %>
+    <span class="tooltiptext">
+      <div>
+        <p>Chancy trade (business) with a high turnover rate and uncertain profitability.</p>
+        <p>The entertainment, eating, and drinking business.</p>
+        <p>The night entertainment (nightlife) business.</p>
+      </div>
+    </span>
+  </div>
+  <% @activity.activity_questions.each do |e| %>
+    <div class="character-icons">
+      <h1 class="text-center mt-4" id="icon-symbol"><%= e.question_text %></h1>
+      <span class="tooltiptext"><%= e.response_text %></span>
+      <%= audio_tag("#{e.question_text} audio.m4a", id:"icon-audio") %>
+    </div>
+  <% end %>
+</div>
+<%= javascript_include_tag 'icons' %>

--- a/app/views/activities/teacher/_multiple.html.erb
+++ b/app/views/activities/teacher/_multiple.html.erb
@@ -1,0 +1,26 @@
+<div class="text-center">
+  <%= cl_image_tag activity.photos.first.key, usemap: "#map", class: "rounded-2" %>
+  <map name="map">
+    <area id="star1" shape="rect" coords="146,390,288,533" href="" alt="star1" data-bs-toggle="modal" data-bs-target="#modal1">
+    <area id="star2" shape="rect" coords="526,90,646,198" href="https://setapp.com/how-to/paint-for-mac" alt="star2" data-bs-toggle="modal" data-bs-target="#modal2">
+    <area id="star3" shape="rect" coords="973,246,1097,352" href="https://setapp.com/how-to/paint-for-mac" alt="star3" data-bs-toggle="modal" data-bs-target="#modal3">
+    <% activity.activity_questions.each_with_index do |question, i| %>
+      <div class="modal fade" id="modal<%= i + 1 %>" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="exampleModalLabel">Monument National</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <p><%= question.question_text %></p>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </map>
+</div>

--- a/app/views/activities/teacher/_photo_popup.html.erb
+++ b/app/views/activities/teacher/_photo_popup.html.erb
@@ -1,0 +1,28 @@
+<div class="d-flex justify-content-center">
+  <% @activity.activity_questions.each do |question| %>
+    <div class="d-flex flex-column align-items-center" data-controller="">
+      <% question.photos.each do |photo| %>
+        <button type="button" class="btn" data-bs-toggle="modal" data-bs-target="#staticBackdrop<%= question.id %>" style="box-shadow: none">
+          <%= cl_image_tag photo.key, height: 500, width: 400, crop: :fill, class: "rounded-2 m-1", style: "box-shadow: 0 5px 9px rgba(0,0,0,0.2);" %>
+        </button>
+      <% end %>
+
+      <div class="modal fade" id="staticBackdrop<%= question.id %>" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h1 class="modal-title fs-5" id="staticBackdropLabel"><%= question.question_text.truncate_words(2) %></h1>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <%= question.question_text %>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cool!</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/activities/teacher/_video_quiz.html.erb
+++ b/app/views/activities/teacher/_video_quiz.html.erb
@@ -1,0 +1,16 @@
+<% if @activity.video %>
+  <div class="question d-flex flex-column align-items-center">
+    <div class="text-center mb-3"><iframe data-video-questions-target="video" width="560" height="315" src="https://www.youtube.com/embed/<%= activity.video %>" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>
+  </div>
+<% end %>
+<% @activity.activity_questions.each_with_index do |question, i| %>
+  <div class="question">
+    <h4 class="mb-2"><%= i + 1 %>. <%= question.question_text %></h4>
+    <% if question.choices.any? %>
+      <% question.choices.each do |choice| %>
+        <li> <%= choice %> </li>
+      <% end %>
+    <% end %>
+    <p class="my-2"><%= "The correct answer is: #{question.response_text}" %></p>
+  </div>
+<% end %>

--- a/app/views/classrooms/show.html.erb
+++ b/app/views/classrooms/show.html.erb
@@ -24,7 +24,7 @@
             <% comments = 0 %>
             <% activity.activity_questions.each do |question| %>
               <% question.user_responses.each do |response| %>
-                <% response.teacher_comments != nil ? comments += 1 : comments = comments %>
+                <% response.teacher_comments.blank? ? comments = comments : comments += 1 %>
               <% end %>
             <% end %>
             <% if @classroom.activities.include?(b.activity.title) %>

--- a/app/views/classrooms/show.html.erb
+++ b/app/views/classrooms/show.html.erb
@@ -30,12 +30,14 @@
             <% if @classroom.activities.include?(b.activity.title) %>
               <% if b.status == "marked" || b.status == "completed" %>
                 <div class="mx-2 d-flex flex-column align-items-center" style="width: 150px">
-                  <div class="badge <%= b.status.to_sym %>-color" style="white-space:normal">
-                    <p ><%= link_to b.activity.title, results_path(student, b.activity) %></p>
-                    <span class="tooltiptext">
-                      You have <%= comments %> comments on this activity
-                    </span>
-                  </div>
+                  <%= link_to results_path(student, b.activity), style: "text-decoration: none" do %>
+                    <div class="badge <%= b.status.to_sym %>-color" style="white-space:normal">
+                      <p><%= b.activity.title %></p>
+                      <span class="tooltiptext">
+                        You have <%= comments %> comments on this activity
+                      </span>
+                    </div>
+                  <% end %>
                   <% completed_badges << b if b.status == "completed" %>
                   <%# <%= link_to b.activity.title, results_path(student, b.activity), class: "badge #{b.status.to_sym}-color", style: "white-space:normal" %>
                 </div>

--- a/app/views/classrooms/show.html.erb
+++ b/app/views/classrooms/show.html.erb
@@ -34,17 +34,16 @@
                     <div class="badge <%= b.status.to_sym %>-color" style="white-space:normal">
                       <p><%= b.activity.title %></p>
                       <span class="tooltiptext">
-                        You have <%= comments %> comments on this activity
+                        You left <%= comments %> comments on this activity
                       </span>
                     </div>
                   <% end %>
                   <% completed_badges << b if b.status == "completed" %>
-                  <%# <%= link_to b.activity.title, results_path(student, b.activity), class: "badge #{b.status.to_sym}-color", style: "white-space:normal" %>
                 </div>
               <% else %>
-                 <div class="mx-2 d-flex flex-column align-items-center" style="width: 150px">
+                <div class="mx-2 d-flex flex-column align-items-center" style="width: 150px">
                   <p class="badge <%= b.status.to_sym %>-color" style="white-space:normal">
-                    <%=  b.activity.title  %>
+                    <%= b.activity.title %>
                   </p>
                   <% completed_badges << b if b.status == "completed" %>
                 </div>


### PR DESCRIPTION
**Classroom:**
- Made entire badge clickable.
- Fixed # of comments displayed in tooltip over badge (was counting user_responses instead of teacher_comments).
**Check to see if comments displayed make sense**

**Activities:**
- Made partials for activities displayed to the teacher through the activities page, under `activities/teacher` folder.

Test by signing in as a teacher and clicking on each activity through the Activities page. 
- For photo pop-ups and icon/audio, should be able to see the photos and hear the audio etc.
- For quizzes and crossword, should be able to see the multiple choices and their correct answers.
- For essay/review, only the description.