### PR TITLE
Signup validations

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,5 +19,5 @@ application.register("map", MapController)
 import SignupController from "./signup_controller"
 application.register("signup", SignupController)
 
-import VideoQuestions from "./video_questions_controller"
-application.register("video-questions", VideoQuestions)
+import VideoQuestionsController from "./video_questions_controller"
+application.register("video-questions", VideoQuestionsController)

--- a/app/javascript/controllers/signup_controller.js
+++ b/app/javascript/controllers/signup_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="signup"
 export default class extends Controller {
-  static targets = ["codeText", "radioButtons"]
+  static targets = ["codeText"]
 
   connect() {
   }
@@ -11,8 +11,10 @@ export default class extends Controller {
     // console.log(event.target.value);
     if (event.target.value == 'false') {
       this.codeTextTarget.innerHTML = "This is the code given to you by your teacher. <br> With this code, you will be added to your virtual classroom with your teacher and your peers."
+      this.codeTextTarget.setAttribute("id","student-code")
     } else if (event.target.value == 'true') {
       this.codeTextTarget.innerHTML = "This is the code given to you by Tableau D'Hote. <br> With this code, a classroom will be created for your students where you will be assigned as their teacher."
+      this.codeTextTarget.setAttribute("id","teacher-code")
     }
   }
 
@@ -31,11 +33,13 @@ export default class extends Controller {
   displayCodeError(event) {
     // Check if Teacher
     // If access code is not 'placeholderTC' show error
-    if (this.radioButtonsTarget.value == 'true') {
+    // console.log(this.codeTextTarget);
+    if (this.codeTextTarget.id == 'teacher-code') {
       if (event.target.value != 'placeholderTC') {
         event.target.classList.add("is-invalid", "border", "border-danger", "rounded")
       }
       else if (event.target.value == 'placeholderTC') {
+        event.target.classList.add("is-valid")
         event.target.classList.remove("is-invalid","border", "border-danger", "rounded")
       }
     }

--- a/app/javascript/controllers/signup_controller.js
+++ b/app/javascript/controllers/signup_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="signup"
 export default class extends Controller {
-  static targets = ["codeText"]
+  static targets = ["codeText", "radioButtons"]
 
   connect() {
   }
@@ -13,6 +13,31 @@ export default class extends Controller {
       this.codeTextTarget.innerHTML = "This is the code given to you by your teacher. <br> With this code, you will be added to your virtual classroom with your teacher and your peers."
     } else if (event.target.value == 'true') {
       this.codeTextTarget.innerHTML = "This is the code given to you by Tableau D'Hote. <br> With this code, a classroom will be created for your students where you will be assigned as their teacher."
+    }
+  }
+
+  displayError(event) {
+    // console.log(event.target.value);
+    if (event.target.value == '') {
+      event.target.classList.add("is-invalid", "border", "border-danger", "rounded")
+      event.target.setAttribute("placeholder", "Cannot be blank.")
+    }
+    else if (event.target.value != '') {
+      event.target.classList.add("is-valid")
+      event.target.classList.remove("is-invalid","border", "border-danger", "rounded")
+    }
+  }
+
+  displayCodeError(event) {
+    // Check if Teacher
+    // If access code is not 'placeholderTC' show error
+    if (this.radioButtonsTarget.value == 'true') {
+      if (event.target.value != 'placeholderTC') {
+        event.target.classList.add("is-invalid", "border", "border-danger", "rounded")
+      }
+      else if (event.target.value == 'placeholderTC') {
+        event.target.classList.remove("is-invalid","border", "border-danger", "rounded")
+      }
     }
   }
 }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,19 +6,8 @@
     <p class="my-3">Already have an account? <%= render "devise/shared/links" %></p>
   </div>
 
-  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }, html: { onkeydown: "return event.key != 'Enter';"} ) do |f| %>
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }, html: { onkeydown: "return event.key != 'Enter';", class: "form-floating" } ) do |f| %>
     <%= f.error_notification %>
-
-    <% if resource.errors.any? %>
-      <div id="error_explanation">
-        <h2><%= pluralize(resource.errors.count, "error") %> prohibited your account from being created:</h2>
-        <ul>
-          <% resource.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
 
     <div class="form-inputs" data-controller="signup">
       <div id="frame1" class="frame">
@@ -27,12 +16,12 @@
           <div class="flex-fill me-2">
             <%= f.input :first_name,
                         required: true,
-                        input_html: { autocomplete: "First Name"} %>
+                        input_html: { autocomplete: "First Name", data: { action: "focusout->signup#displayError" }} %>
           </div>
           <div class="flex-fill">
             <%= f.input :last_name,
                         required: true,
-                        input_html: { autocomplete: "Last Name" } %>
+                        input_html: { autocomplete: "Last Name", data: { action: "focusout->signup#displayError" } } %>
           </div>
         </div>
         <%= link_to "#frame2", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
@@ -49,7 +38,7 @@
                     collection_wrapper_tag: 'div',
                     collection_wrapper_class: 'category-wrapper',
                     item_wrapper_class: 'category-item',
-                    input_html: { class: 'category-selector', data: { action: "change->signup#displayText" }} %>
+                    input_html: { class: 'category-selector', data: { action: "change->signup#displayText", signup_target: "radioButtons" }} %>
         <%= link_to "#frame3", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
           OK <i class="fa-solid fa-check"></i>
         <% end %>
@@ -63,7 +52,7 @@
                     required: true,
                     label: false,
                     placeholder: "Enter your code...",
-                    input_html: { autocomplete: "access_code" } %>
+                    input_html: { autocomplete: "access_code", data: { action: "focusout->signup#displayCodeError" }} %>
         <%= link_to "#frame4", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
           OK <i class="fa-solid fa-check"></i>
         <% end %>
@@ -75,7 +64,7 @@
                     required: true,
                     label: false,
                     placeholder: "Enter your email...",
-                    input_html: { autocomplete: "email" } %>
+                    input_html: { autocomplete: "email", data: { action: "focusout->signup#displayError" } } %>
         <%= link_to "#frame5", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
           OK <i class="fa-solid fa-check"></i>
         <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -38,7 +38,7 @@
                     collection_wrapper_tag: 'div',
                     collection_wrapper_class: 'category-wrapper',
                     item_wrapper_class: 'category-item',
-                    input_html: { class: 'category-selector', data: { action: "change->signup#displayText", signup_target: "radioButtons" }} %>
+                    input_html: { class: 'category-selector', data: { action: "change->signup#displayText" }} %>
         <%= link_to "#frame3", class: "btn btn-primary", data: { controller: "scroll-to" } do %>
           OK <i class="fa-solid fa-check"></i>
         <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,6 +9,17 @@
   <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }, html: { onkeydown: "return event.key != 'Enter';"} ) do |f| %>
     <%= f.error_notification %>
 
+    <% if resource.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(resource.errors.count, "error") %> prohibited your account from being created:</h2>
+        <ul>
+          <% resource.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
     <div class="form-inputs" data-controller="signup">
       <div id="frame1" class="frame">
         <h3 class="my-5">Let's start with your name.</h3>


### PR DESCRIPTION
**What changed:**
- Added some actions in signup_controller.js to handle live display of signup form validations.
- Used bootstrap classes "valid" and "is-invalid" for inputs.

**How to test:**
- Go to sign up page and follow the flow.
- If an input is left blank, you should see an error in the input as below: <img width="462" alt="Screen Shot 2023-01-25 at 2 20 58 PM" src="https://user-images.githubusercontent.com/100733281/214666890-954382d1-700e-48cb-ab0f-033251b97a90.png">
- Once the input is filled, it will have a green check mark: <img width="462" alt="Screen Shot 2023-01-25 at 2 21 06 PM" src="https://user-images.githubusercontent.com/100733281/214665730-e693ee31-5110-4b11-9355-eb698eee95f1.png">
- When signing up as a teacher, the access code input should be red if you input anything other than "placeholderTC"
- When signing up as a student, the access code input won't display any live error

**Potential Improvements:** Could be more specific validations (i.e. more than 1 character for First Name etc. but I don't think using JS is the right way to go about that.)